### PR TITLE
Add initial draft of correlation test script

### DIFF
--- a/src/run_test.R
+++ b/src/run_test.R
@@ -1,0 +1,35 @@
+# author: Rafael Pilliard Hellwig
+# date: 2020-11-24
+
+"Perform Pearson' Product Moment Correlation Test
+
+Usage: src/run_test.R [--input=<input>] [--out_dir=<out_dir>]
+
+Options:
+--input=<input>        Path (including filename) to cleaned data (saved as
+                       an RDS data frame with numeric columns `competitiveness`
+                       and `turnout`) [default: data/processed/pvr_agg.rds]
+--out_dir=<out_dir>    Path to directory where the results should be saved (as
+                       an RDS file) [default: data/processed]
+" -> doc
+
+# load packages
+library(docopt)
+
+# load shell parameters
+opt <- docopt(doc)
+
+main <- function(data, out_dir = "data/processed") {
+
+  # load data
+  pvr_agg <- readRDS(data)
+
+  # perform a correlation test
+  test_1 <- stats::cor.test(~turnout+competitiveness, data = pvr_agg)
+  tidytest_1 <- broom::tidy(test_1)
+
+  # write the results to disk
+  saveRDS(tidytest_1, here::here(out_dir, "cor_test.rds"))
+}
+
+main(opt[["--input"]], opt[["--out_dir"]])


### PR DESCRIPTION
This script performs a `cor.test()` between `competitiveness` and `turnout` and writes the tidy result to `data/processed`.

Note, this requires the tidied data `data/processed/pvr_agg.rds` to exist (not committed here). I only released this as a draft PR, as some edits may be necessary based on the upstream scripts.